### PR TITLE
Do a minor adjustment to NPC colliding with negative items

### DIFF
--- a/GGK/Assets/Scenes/RIT Outer Loop Greybox.unity
+++ b/GGK/Assets/Scenes/RIT Outer Loop Greybox.unity
@@ -37209,6 +37209,9 @@ MonoBehaviour:
   topMaxSpeed: 0
   boosted: 0
   boostDistanceMultiplier: 4
+  isRecoveringFromHit: 0
+  recoveryTimer: 0
+  recoveryDuration: 2.5
 --- !u!54 &2013023915
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -37286,7 +37289,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   thisDriver: {fileID: 0}
-  npcDriver: {fileID: 0}
+  npcDriver: {fileID: 2013023914}
   heldItem: {fileID: 0}
   timer: 5
   itemDisplay: {fileID: 0}
@@ -54318,6 +54321,9 @@ MonoBehaviour:
   topMaxSpeed: 0
   boosted: 0
   boostDistanceMultiplier: 4
+  isRecoveringFromHit: 0
+  recoveryTimer: 0
+  recoveryDuration: 2.5
 --- !u!65 &5954472818605481480
 BoxCollider:
   m_ObjectHideFlags: 0

--- a/GGK/Assets/Scripts/ItemScripts/ItemHolder.cs
+++ b/GGK/Assets/Scripts/ItemScripts/ItemHolder.cs
@@ -135,11 +135,12 @@ public class ItemHolder : MonoBehaviour
             }
             else if (npcDriver != null)
             {
-                npcDriver.DisableDriving();
-                npcDriver.velocity /= 8000;
-                npcDriver.maxSpeed = 100;
-                npcDriver.accelerationRate = 500;
-                npcDriver.followTarget.GetComponent<SplineAnimate>().enabled = false;
+                //npcDriver.DisableDriving();
+                //npcDriver.velocity /= 8000;
+                //npcDriver.maxSpeed = 100;
+                //npcDriver.accelerationRate = 500;
+                //npcDriver.followTarget.GetComponent<SplineAnimate>().enabled = false;
+                npcDriver.StartRecovery();
             }
         }
 
@@ -215,11 +216,13 @@ public class ItemHolder : MonoBehaviour
             }
             else if (npcDriver != null)
             {
-                npcDriver.DisableDriving();
-                npcDriver.velocity /= 8000;
-                npcDriver.maxSpeed = 100;
-                npcDriver.accelerationRate = 500;
-                npcDriver.followTarget.GetComponent<SplineAnimate>().enabled = false;
+                //npcDriver.DisableDriving();
+                //npcDriver.velocity /= 8;
+                //npcDriver.maxSpeed = 100;
+                //npcDriver.accelerationRate = 500;
+                //npcDriver.followTarget.GetComponent<SplineAnimate>().enabled = false;
+
+                npcDriver.StartRecovery();
             }
         }
     }


### PR DESCRIPTION
Smooth out the process when a kart collide with a negative effect item and only decrease the speed without snapping the kart up and down