### PR TITLE
Volume methods added?

### DIFF
--- a/GGK/Assets/Scenes/StartScene.unity
+++ b/GGK/Assets/Scenes/StartScene.unity
@@ -1380,6 +1380,7 @@ GameObject:
   - component: {fileID: 1555633134}
   - component: {fileID: 1555633135}
   - component: {fileID: 1555633136}
+  - component: {fileID: 1555633138}
   - component: {fileID: 1555633137}
   m_Layer: 0
   m_Name: GameManager
@@ -1400,6 +1401,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 63eabf7b426a71640a1bc36263bf3192, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  curState: 0
   sceneLoader: {fileID: 1555633137}
   currentSceneFirst: {fileID: 0}
 --- !u!4 &1555633133
@@ -1457,7 +1459,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1c58e1a953fafd14aac4136fdeaa7bf9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  volume: 100
+  masterVolume: 100
+  dialougeVolume: 100
+  sfxVolume: 100
+  musicVolume: 100
 --- !u!114 &1555633137
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1471,8 +1476,21 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   transition: {fileID: 1319836764}
-  transitionTime: 1.5
+  transitionTime: 1
   transitionActive: 1
+--- !u!114 &1555633138
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1555633131}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6fb5871f021cc124fbe6ef6ccc08f7b9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  optionsData: {fileID: 1555633136}
 --- !u!1 &1798033627
 GameObject:
   m_ObjectHideFlags: 0

--- a/GGK/Assets/Scripts/GameManagers/OptionsData.cs
+++ b/GGK/Assets/Scripts/GameManagers/OptionsData.cs
@@ -14,10 +14,10 @@ public class OptionsData : MonoBehaviour
     public GameManager GameManager { get { return gameManager; } }
 
     // Data
-    public int masterVolume = 100;
-    public int dialougeVolume = 100;
-    public int sfxVolume = 100;
-    public int musicVolume = 100;
+    public float masterVolume = 100;
+    public float dialougeVolume = 100;
+    public float sfxVolume = 100;
+    public float musicVolume = 100;
 
     // Start is called before the first frame update
     void Start()

--- a/GGK/Assets/Scripts/SoundScripts/SoundVolume.cs
+++ b/GGK/Assets/Scripts/SoundScripts/SoundVolume.cs
@@ -1,0 +1,26 @@
+using System.Collections;
+using System.Collections.Generic;
+using Unity.VisualScripting;
+using UnityEngine;
+
+public class SoundVolume : MonoBehaviour
+{
+    // Reference
+    public OptionsData optionsData;
+
+    // Volume Methods
+    public void PlayDialouge(AudioSource audioSource, AudioClip audioClip)
+    {
+        audioSource.PlayOneShot(audioClip, (optionsData.masterVolume / 100) * (optionsData.dialougeVolume / 100));
+    }
+
+    public void PlaySFX(AudioSource audioSource, AudioClip audioClip)
+    {
+        audioSource.PlayOneShot(audioClip, (optionsData.masterVolume / 100) * (optionsData.sfxVolume / 100));
+    }
+
+    public void PlayMusic(AudioSource audioSource, AudioClip audioClip)
+    {
+        audioSource.PlayOneShot(audioClip, (optionsData.masterVolume / 100) * (optionsData.musicVolume / 100));
+    }
+}

--- a/GGK/Assets/Scripts/SoundScripts/SoundVolume.cs.meta
+++ b/GGK/Assets/Scripts/SoundScripts/SoundVolume.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6fb5871f021cc124fbe6ef6ccc08f7b9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Still needed to be used somewhere and sound team may or may not have a better idea.

Also lowered transition time. Old code was somewhat of a screwup as I tried to anticipate how long it would take for the animation of the start and end total to finish when I can just add add a yield in the middle and trigger the animations separately with different triggers?