### PR TITLE
Trap items

### DIFF
--- a/GGK/Assets/Prefabs/ItemPrefabs/ConfusedRitche.prefab
+++ b/GGK/Assets/Prefabs/ItemPrefabs/ConfusedRitche.prefab
@@ -13,9 +13,8 @@ GameObject:
   - component: {fileID: 474482432562938953}
   - component: {fileID: 6700976075920660207}
   - component: {fileID: -2140440458312195221}
-  - component: {fileID: -6932321184112653294}
   m_Layer: 3
-  m_Name: FakeItemBox
+  m_Name: ConfusedRitche
   m_TagString: Hazard
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -43,7 +42,7 @@ MeshFilter:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 9117759039799724987}
-  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!23 &474482432562938953
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -64,7 +63,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: 112bb6e938500964587c6f7d6bff95c7, type: 2}
+  - {fileID: 2100000, guid: cda38090a9c1cb74f976f018e305f2fa, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -134,22 +133,3 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 126
   m_CollisionDetection: 0
---- !u!114 &-6932321184112653294
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9117759039799724987}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8044fcaf0c56b1f448367db2d69bfa64, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  timer: 30
-  rb: {fileID: -2140440458312195221}
-  itemCategory: FakeItemBox
-  useCount: 1
-  isTimed: 0
-  itemIcon: {fileID: 2800000, guid: 1ad214199b390f440bba4813bde47118, type: 3}
-  hazardSound: {fileID: 8300000, guid: a7c27e308abc8c14cacb62041ebc16d2, type: 3}

--- a/GGK/Assets/Prefabs/ItemPrefabs/ConfusedRitche.prefab.meta
+++ b/GGK/Assets/Prefabs/ItemPrefabs/ConfusedRitche.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9defcc1d57fa8b94bb67ef0d1b280972
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/GGK/Assets/Prefabs/ItemPrefabs/CrackedBrickWall.prefab
+++ b/GGK/Assets/Prefabs/ItemPrefabs/CrackedBrickWall.prefab
@@ -13,9 +13,8 @@ GameObject:
   - component: {fileID: 474482432562938953}
   - component: {fileID: 6700976075920660207}
   - component: {fileID: -2140440458312195221}
-  - component: {fileID: -6932321184112653294}
   m_Layer: 3
-  m_Name: FakeItemBox
+  m_Name: CrackedBrickWall
   m_TagString: Hazard
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -31,8 +30,8 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 2.5, y: 2.5, z: 2.5}
-  m_ConstrainProportionsScale: 1
+  m_LocalScale: {x: 4, y: 4, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -64,7 +63,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: 112bb6e938500964587c6f7d6bff95c7, type: 2}
+  - {fileID: 2100000, guid: b9adce2efd3460c4db3379d04d30be3f, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -102,7 +101,7 @@ BoxCollider:
     m_Bits: 0
   m_LayerOverridePriority: 0
   m_IsTrigger: 1
-  m_ProvidesContacts: 0
+  m_ProvidesContacts: 1
   m_Enabled: 1
   serializedVersion: 3
   m_Size: {x: 1, y: 1, z: 1}
@@ -134,22 +133,3 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 126
   m_CollisionDetection: 0
---- !u!114 &-6932321184112653294
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9117759039799724987}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8044fcaf0c56b1f448367db2d69bfa64, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  timer: 30
-  rb: {fileID: -2140440458312195221}
-  itemCategory: FakeItemBox
-  useCount: 1
-  isTimed: 0
-  itemIcon: {fileID: 2800000, guid: 1ad214199b390f440bba4813bde47118, type: 3}
-  hazardSound: {fileID: 8300000, guid: a7c27e308abc8c14cacb62041ebc16d2, type: 3}

--- a/GGK/Assets/Prefabs/ItemPrefabs/CrackedBrickWall.prefab.meta
+++ b/GGK/Assets/Prefabs/ItemPrefabs/CrackedBrickWall.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 36af317b638c1fc488b4435d8722ef8a
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/GGK/Assets/Prefabs/ItemPrefabs/Spill.prefab
+++ b/GGK/Assets/Prefabs/ItemPrefabs/Spill.prefab
@@ -31,7 +31,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 4.4, y: 0.8, z: 4.4}
+  m_LocalScale: {x: 5, y: 1, z: 5}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}

--- a/GGK/Assets/Prefabs/ItemPrefabs/TrapItem.prefab
+++ b/GGK/Assets/Prefabs/ItemPrefabs/TrapItem.prefab
@@ -31,7 +31,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 4.4, y: 0.8, z: 4.4}
+  m_LocalScale: {x: 5, y: 1, z: 5}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
@@ -155,9 +155,9 @@ MonoBehaviour:
   hazardSound: {fileID: 8300000, guid: a7c27e308abc8c14cacb62041ebc16d2, type: 3}
   tierOneBody: {fileID: 767706840856509470, guid: 793d97737815c3e4bb2dd48f19109467, type: 3}
   tierOneIcon: {fileID: 2800000, guid: 42dbbbc2a70a56a428ae0fcba94e9fb3, type: 3}
-  tierTwoBody: {fileID: 9117759039799724987, guid: 0b518e80a6b139940be4f5af15419f04, type: 3}
+  tierTwoBody: {fileID: 9117759039799724987, guid: 36af317b638c1fc488b4435d8722ef8a, type: 3}
   tierTwoIcon: {fileID: 2800000, guid: 1ad214199b390f440bba4813bde47118, type: 3}
-  tierThreeBody: {fileID: 9117759039799724987, guid: 0b518e80a6b139940be4f5af15419f04, type: 3}
-  tierThreeIcon: {fileID: 2800000, guid: 1ad214199b390f440bba4813bde47118, type: 3}
+  tierThreeBody: {fileID: 9117759039799724987, guid: 9defcc1d57fa8b94bb67ef0d1b280972, type: 3}
+  tierThreeIcon: {fileID: 2800000, guid: e4abe763de9f7ca4d94e64a4c2f26b9e, type: 3}
   tierFourBody: {fileID: 9117759039799724987, guid: 0b518e80a6b139940be4f5af15419f04, type: 3}
-  tierFourIcon: {fileID: 2800000, guid: 1ad214199b390f440bba4813bde47118, type: 3}
+  tierFourIcon: {fileID: 2800000, guid: 8f2b2479fa8a5aa4ea2f81547262713c, type: 3}

--- a/GGK/Assets/Scenes/TestingScenes/TrapItemTest.unity
+++ b/GGK/Assets/Scenes/TestingScenes/TrapItemTest.unity
@@ -122,6 +122,76 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1001 &36697211
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 336256357}
+    m_Modifications:
+    - target: {fileID: 1093172496520741459, guid: eb931ffa2ae727e44b93c585f8461c6f, type: 3}
+      propertyPath: items.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1093172496520741459, guid: eb931ffa2ae727e44b93c585f8461c6f, type: 3}
+      propertyPath: items.Array.data[0]
+      value: 
+      objectReference: {fileID: 2055685921588137374, guid: 2d9ffd843713ab44ea7ca3210ee15e1d, type: 3}
+    - target: {fileID: 1106090965097549554, guid: eb931ffa2ae727e44b93c585f8461c6f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1106090965097549554, guid: eb931ffa2ae727e44b93c585f8461c6f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1106090965097549554, guid: eb931ffa2ae727e44b93c585f8461c6f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1106090965097549554, guid: eb931ffa2ae727e44b93c585f8461c6f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1106090965097549554, guid: eb931ffa2ae727e44b93c585f8461c6f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1106090965097549554, guid: eb931ffa2ae727e44b93c585f8461c6f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1106090965097549554, guid: eb931ffa2ae727e44b93c585f8461c6f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1106090965097549554, guid: eb931ffa2ae727e44b93c585f8461c6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1106090965097549554, guid: eb931ffa2ae727e44b93c585f8461c6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1106090965097549554, guid: eb931ffa2ae727e44b93c585f8461c6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8843868577639019765, guid: eb931ffa2ae727e44b93c585f8461c6f, type: 3}
+      propertyPath: m_Name
+      value: ItemBox (1)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: eb931ffa2ae727e44b93c585f8461c6f, type: 3}
+--- !u!4 &36697212 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1106090965097549554, guid: eb931ffa2ae727e44b93c585f8461c6f, type: 3}
+  m_PrefabInstance: {fileID: 36697211}
+  m_PrefabAsset: {fileID: 0}
 --- !u!54 &51584207 stripped
 Rigidbody:
   m_CorrespondingSourceObject: {fileID: 8245124639533166686, guid: 70f3f5e5c45e980468240d1d68b45b1d, type: 3}
@@ -348,6 +418,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 931350262}
+  - {fileID: 36697212}
   - {fileID: 144096934}
   - {fileID: 1018686610}
   - {fileID: 1474003605}
@@ -1303,6 +1374,111 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1018533858
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1018533862}
+  - component: {fileID: 1018533861}
+  - component: {fileID: 1018533860}
+  - component: {fileID: 1018533859}
+  m_Layer: 0
+  m_Name: Wall
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!65 &1018533859
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1018533858}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &1018533860
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1018533858}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1018533861
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1018533858}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1018533862
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1018533858}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0.7071068, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: 30, y: 5, z: -10}
+  m_LocalScale: {x: 10, y: 10, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
 --- !u!1001 &1018686609
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2746,6 +2922,7 @@ SceneRoots:
   m_Roots:
   - {fileID: 1649279057}
   - {fileID: 1463940752}
+  - {fileID: 1018533862}
   - {fileID: 856113722}
   - {fileID: 1635484028}
   - {fileID: 705533466}

--- a/GGK/Assets/Scripts/DriverScripts/NEWDriver.cs
+++ b/GGK/Assets/Scripts/DriverScripts/NEWDriver.cs
@@ -115,6 +115,10 @@ public class NEWDriver : MonoBehaviour
 
     public bool isDriving;
 
+    [Header("Confused Settings")]
+    public bool isConfused;
+    public float confusedTimer;
+
     // Start is called before the first frame update
     void Start()
     {
@@ -319,6 +323,16 @@ public class NEWDriver : MonoBehaviour
             sphere.AddForce(tractionForce, ForceMode.Acceleration);
         }
 
+        //------------Confused Timer---------------------
+        if (isConfused)
+        {
+            confusedTimer -= Time.deltaTime;
+
+            if (confusedTimer <= 0)
+            {
+                isConfused = false;
+            }
+        }
     }
 
 
@@ -854,7 +868,15 @@ public class NEWDriver : MonoBehaviour
 
     public void OnMove(InputAction.CallbackContext context)
     {
-        movementDirection = context.ReadValue<Vector2>();
+        Vector2 input = context.ReadValue<Vector2>();
+
+        // Reverse Inputs
+        if (isConfused)
+        {
+            input *= -1;
+        }
+
+        movementDirection = input;
 
         movementDirection.z = movementDirection.y;
 
@@ -898,13 +920,29 @@ public class NEWDriver : MonoBehaviour
 
     public void OnTurn(InputAction.CallbackContext context)
     {
-        controllerX = context.ReadValue<float>();
+        float input = context.ReadValue<float>();
+
+        // Reverse Inputs
+        if (isConfused)
+        {
+            input *= -1;
+        }
+
+        controllerX = input;
         UpdateControllerMovement(context);
     }
 
     public void OnAcceleration(InputAction.CallbackContext context)
     {
-        controllerZ = context.ReadValue<float>();
+        float input = context.ReadValue<float>();
+
+        // Reverse Inputs
+        if (isConfused)
+        {
+            input *= -1;
+        }
+
+        controllerZ = input;
         UpdateControllerMovement(context);
 
         if (context.started)

--- a/GGK/Assets/Scripts/DriverScripts/NEWDriver.cs
+++ b/GGK/Assets/Scripts/DriverScripts/NEWDriver.cs
@@ -122,7 +122,6 @@ public class NEWDriver : MonoBehaviour
     // Player info for API
     // The player info should be created in the Login handeler and player data filled out in here   TODO (Logan)
     // Any game related data will be filled in in the game scene handeler or manager
-    [Header("API Settings")]
     private PlayerInfo playerInfo;
     private GameManager gameManagerObj;
 

--- a/GGK/Assets/Scripts/DriverScripts/NEWDriver.cs
+++ b/GGK/Assets/Scripts/DriverScripts/NEWDriver.cs
@@ -331,6 +331,7 @@ public class NEWDriver : MonoBehaviour
             if (confusedTimer <= 0)
             {
                 isConfused = false;
+                movementDirection *= -1; // Just here to forces confusion to activate even if you don't change movement input
             }
         }
     }

--- a/GGK/Assets/Scripts/ItemScripts/ItemHolder.cs
+++ b/GGK/Assets/Scripts/ItemScripts/ItemHolder.cs
@@ -345,6 +345,7 @@ public class ItemHolder : MonoBehaviour
                 {
                     thisDriver.confusedTimer = 10;
                     thisDriver.isConfused = true;
+                    thisDriver.movementDirection *= -1; // Just here to forces confusion to activate even if you don't change movement input
                 }
             }
             else if (npcDriver != null)

--- a/GGK/Assets/Scripts/ItemScripts/ItemHolder.cs
+++ b/GGK/Assets/Scripts/ItemScripts/ItemHolder.cs
@@ -107,12 +107,13 @@ public class ItemHolder : MonoBehaviour
             {
                 if (uses == 0)
                 {
-                    heldItem = null;
+                    // heldItem = null;
                     holdingItem = false;
                     if (thisDriver)
                     {
                         itemDisplay.texture = defaultItemDisplay;
                     }
+                    Destroy(heldItem.gameObject);
                 }
             }
             else if (item.UseCount > 1 && item.isTimed)
@@ -133,12 +134,13 @@ public class ItemHolder : MonoBehaviour
             {
                 if (uses == 0)
                 {
-                    heldItem = null;
+                    // heldItem = null;
                     holdingItem = false;
                     if (thisDriver)
                     {
                         itemDisplay.texture = defaultItemDisplay;
                     }
+                    Destroy(heldItem.gameObject);
                 }
             }
         }
@@ -334,10 +336,9 @@ public class ItemHolder : MonoBehaviour
         // checks if the kart drives into a hazard and drops the velocity to 1/8th of the previous value
         if (collision.gameObject.transform.tag == "Hazard")
         {
-            Destroy(collision.gameObject);
+            
             if (thisDriver != null)
             {
-
                 thisDriver.sphere.velocity /= 8000;
             }
             else if (npcDriver != null)
@@ -350,6 +351,7 @@ public class ItemHolder : MonoBehaviour
 
                 npcDriver.StartRecovery();
             }
+            Destroy(collision.gameObject);
         }
 
     }

--- a/GGK/Assets/Scripts/ItemScripts/ItemHolder.cs
+++ b/GGK/Assets/Scripts/ItemScripts/ItemHolder.cs
@@ -336,10 +336,16 @@ public class ItemHolder : MonoBehaviour
         // checks if the kart drives into a hazard and drops the velocity to 1/8th of the previous value
         if (collision.gameObject.transform.tag == "Hazard")
         {
-            
             if (thisDriver != null)
             {
                 thisDriver.sphere.velocity /= 8000;
+
+                // Checks if hazard is Confused Ritchie
+                if (collision.gameObject.GetComponent<TrapItem>().ItemTier == 3)
+                {
+                    thisDriver.confusedTimer = 10;
+                    thisDriver.isConfused = true;
+                }
             }
             else if (npcDriver != null)
             {

--- a/GGK/Assets/Scripts/ItemScripts/TrapItem.cs
+++ b/GGK/Assets/Scripts/ItemScripts/TrapItem.cs
@@ -39,13 +39,13 @@ public class TrapItem : BaseItem
     // Update is called once per frame
     void Update()
     {
-        if (itemTier > 1)
+        if (itemTier > 2)
         {
             RotateBox();
         }
     }
 
-    // Code for fake item box
+    // Code for fake item box & Confused Ritchie
     public void RotateBox()
     {
         transform.rotation *= new Quaternion(0.0f, 2.0f * Time.deltaTime, 0.0f, 1.0f);
@@ -70,7 +70,7 @@ public class TrapItem : BaseItem
                 break;
         }
     }
-
+    
     // So I don't have to write this out 4 times in LevelUp(), just swap out the tier body and icon for different levels
     public void UpdateComponents(GameObject body, Texture icon)
     {


### PR DESCRIPTION
trap items should now be mostly working

Changes
- FakeItemBox, OilSlick, and TrapItem scale changed
- CrackedBrickWall appearance prefab created with placeholder icon and texture (Same Functionality as OilSlick currently, just vertical)
- ConfusedRitchie appearance prefab created with placeholder icon, texture, and model
    - Confusion status added by making changes to ItemHolder and NEWDriver scripts
- Clone of use-based items are now destroyed if used up (changes made to ItemHolder script)