### PR TITLE
Death plane fix

### DIFF
--- a/GGK/Assets/DynamicRecovery.cs
+++ b/GGK/Assets/DynamicRecovery.cs
@@ -92,6 +92,7 @@ public class DynamicRecovery : MonoBehaviour
 
 
         //face forward
+        transform.rotation = currentCheckpoint.rotation;
         kartModel.rotation = currentCheckpoint.rotation;
 
         rb.useGravity = false;

--- a/GGK/Assets/Scenes/RIT Outer Loop Greybox.unity
+++ b/GGK/Assets/Scenes/RIT Outer Loop Greybox.unity
@@ -35070,8 +35070,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 100, y: 100}
+  m_AnchoredPosition: {x: -0.0013428, y: -0.0011902}
+  m_SizeDelta: {x: 433.04, y: 479.46}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1658915559
 MonoBehaviour:

--- a/GGK/Assets/Scenes/RIT Outer Loop Greybox.unity
+++ b/GGK/Assets/Scenes/RIT Outer Loop Greybox.unity
@@ -6119,7 +6119,7 @@ MonoBehaviour:
   hoverTime: 2
   fadeTime: 1
   fadeCanvas: {fileID: 1658915561}
-  kartModel: {fileID: 0}
+  kartModel: {fileID: 1330903948}
 --- !u!1001 &739929204
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -17082,7 +17082,7 @@ MonoBehaviour:
   hoverTime: 2
   fadeTime: 1
   fadeCanvas: {fileID: 1658915561}
-  kartModel: {fileID: 0}
+  kartModel: {fileID: 1330903948}
 --- !u!4 &841155122 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 8264439621377251441, guid: dda0392f5141c6c4b8f3cea894a5081b, type: 3}
@@ -31638,6 +31638,11 @@ Transform:
   m_Children: []
   m_Father: {fileID: 1671686728}
   m_LocalEulerAnglesHint: {x: 0, y: -31.908, z: 0}
+--- !u!4 &1330903948 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 9189572482977137924, guid: 70f3f5e5c45e980468240d1d68b45b1d, type: 3}
+  m_PrefabInstance: {fileID: 1638308135}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1331636328
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/GGK/Assets/Scripts/DriverScripts/NEWDriver.cs
+++ b/GGK/Assets/Scripts/DriverScripts/NEWDriver.cs
@@ -109,6 +109,12 @@ public class NEWDriver : MonoBehaviour
     {
         sphere.drag = 0.5f;
 
+        StopParticles();
+    }
+
+    public void StopParticles()
+    {
+        Debug.Log("Particles stopped");
         //-------------Particles----------------
         foreach (ParticleSystem ps in particleSystemsBR)
         {

--- a/GGK/ProjectSettings/ProjectSettings.asset
+++ b/GGK/ProjectSettings/ProjectSettings.asset
@@ -140,8 +140,7 @@ PlayerSettings:
   visionOSBundleVersion: 1.0
   tvOSBundleVersion: 1.0
   bundleVersion: 1.0
-  preloadedAssets:
-  - {fileID: 11400000, guid: 144cb8da0562d214987e08eccf6581af, type: 2}
+  preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0
   m_HolographicPauseOnTrackingLoss: 1


### PR DESCRIPTION
Fixed issues with respawning not aligning Kart to the direction of the track; Fade in overlay used to be small and in the center of the screen, now it covers the whole screen; New "teleport" effect before fading out when going out of bounds. Lose control of the kart when out of bounds, before being placed back onto the track