### PR TITLE
Edited boost stacking fix

### DIFF
--- a/GGK/Assets/Prefabs/ItemBox.prefab
+++ b/GGK/Assets/Prefabs/ItemBox.prefab
@@ -121,9 +121,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   items:
   - {fileID: 4452591039646941683, guid: e4bfa60d79acc0b448a2b48e96843039, type: 3}
-  - {fileID: 4452591039646941683, guid: e4bfa60d79acc0b448a2b48e96843039, type: 3}
-  - {fileID: 4452591039646941683, guid: e4bfa60d79acc0b448a2b48e96843039, type: 3}
-  - {fileID: 4452591039646941683, guid: e4bfa60d79acc0b448a2b48e96843039, type: 3}
+  - {fileID: 4323936219153965337, guid: 3eace89b8f2c3f1458a5f078ec42c750, type: 3}
+  - {fileID: 2055685921588137374, guid: 2d9ffd843713ab44ea7ca3210ee15e1d, type: 3}
+  - {fileID: 5201143229639170716, guid: 7d505bd21db4d624d85fae305326ab5c, type: 3}
 --- !u!54 &-114592648906738114
 Rigidbody:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Rather than use a bool to check if the player is boosted, there's a maxSpeed for boosting which still solves the problem

Also fixed the item box having all items because I forgot to change it back in my last pull request.