### PR TITLE
Changed leaderboard to only appear once the player has finished the race

### DIFF
--- a/GGK/Assets/Scripts/HUDScripts/Leaderboard Controller.cs
+++ b/GGK/Assets/Scripts/HUDScripts/Leaderboard Controller.cs
@@ -38,7 +38,7 @@ public class LeaderboardController : MonoBehaviour
     public void Finished(KartCheckpoint kart)
     {
         // if player kart finishes opens up leaderboard (how will this work in multiplayer?)
-        if (this.GetComponent<NPCDriver>() == null)
+        if (kart.GetComponent<NPCDriver>() == null)
         {
             leaderboard.gameObject.SetActive(true);
         }


### PR DESCRIPTION
Logic was already set up, but an if statement used this instead of kart so it was checking if the instance of this script had a null instance of another script so it always was true.