### PR TITLE
Minor Changes (Read Description)

### DIFF
--- a/GGK/Assets/AppearanceSettings.cs
+++ b/GGK/Assets/AppearanceSettings.cs
@@ -8,38 +8,41 @@ public class AppearanceSettings : MonoBehaviour
     public Sprite icon;
     public Color color;
     public string name;
+
     public List<GameObject> models; // List of GameObjects representing different character models
     CharacterData characterData; // Reference to CharacterData script
+
     // Start is called before the first frame update
     void Start()
     {
-        // Loading characterData
-        characterData = FindAnyObjectByType<CharacterData>();
-        icon = characterData.characterSprite;
-        color = characterData.characterColor;
-        name = characterData.characterName.ToLower();
-        
-
-        // Set correct character model active
-        if(characterData != null)
+        // If player (will need to be changed for multiplayer)
+        if (GetComponent<NEWDriver>())
         {
-            for (int i = 0; i < models.Count; i++)
-                    {
-                        //Setting active correct model
-                        if(name == models[i].name)
-                        {
-                            models[i].SetActive(true);
-                            break;
-                        }
-            
-                        //deleting the models that are not supposed to be active
-                        Destroy(models[i]);
-            
+            // Loading characterData
+            characterData = FindAnyObjectByType<CharacterData>();
+            icon = characterData.characterSprite;
+            color = characterData.characterColor;
+            name = characterData.characterName.ToLower();
 
+            // Set correct character model active
+            if (characterData != null)
+            {
+                for (int i = 0; i < models.Count; i++)
+                {
+                    //Setting active correct model
+                    if (name == models[i].name)
+                    {
+                        models[i].SetActive(true);
+                        break;
                     }
+
+                    //deleting the models that are not supposed to be active
+                    Destroy(models[i]);
+                }
+            }
         }
-        
-        
+        // I think NPC icons and colors are currently manually set in scene,so
+        // Else NPCDriver code when NPCDrivers get a new prefab?
     }
 
     // Update is called once per frame

--- a/GGK/Assets/Prefabs/Kart 1.prefab
+++ b/GGK/Assets/Prefabs/Kart 1.prefab
@@ -121884,7 +121884,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: 841db065e1a6b0d418fe6d94535252f7, type: 3}
       propertyPath: m_Name
-      value: OL
+      value: ol
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: 841db065e1a6b0d418fe6d94535252f7, type: 3}
       propertyPath: m_IsActive

--- a/GGK/Assets/Prefabs/PausePanel.prefab
+++ b/GGK/Assets/Prefabs/PausePanel.prefab
@@ -14,7 +14,7 @@ GameObject:
   - component: {fileID: 4535378574528027157}
   - component: {fileID: 7361402764782777152}
   m_Layer: 5
-  m_Name: ReturnToStartButton
+  m_Name: ReturnToMapButton
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -124,7 +124,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 6293636680191444260}
         m_TargetAssemblyTypeName: PauseHandler, Assembly-CSharp
-        m_MethodName: ReturnToStart
+        m_MethodName: ReturnToMapSelect
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -276,7 +276,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Return to Map Select
+  m_text: Return to Start
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -303,8 +303,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 22
-  m_fontSizeBase: 22
+  m_fontSize: 24
+  m_fontSizeBase: 24
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
@@ -410,7 +410,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Return to Start
+  m_text: Return to Map Select
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -437,8 +437,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 24
-  m_fontSizeBase: 24
+  m_fontSize: 22
+  m_fontSizeBase: 22
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
@@ -493,7 +493,7 @@ GameObject:
   - component: {fileID: 3587241309869255656}
   - component: {fileID: 2813477691317804719}
   m_Layer: 5
-  m_Name: ReturnToMapButton
+  m_Name: ReturnToStartButton
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -603,7 +603,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 6293636680191444260}
         m_TargetAssemblyTypeName: PauseHandler, Assembly-CSharp
-        m_MethodName: ReturnToMapSelect
+        m_MethodName: ReturnToStart
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}

--- a/GGK/Assets/Prefabs/PausePanel.prefab
+++ b/GGK/Assets/Prefabs/PausePanel.prefab
@@ -91,10 +91,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
-    m_Mode: 3
+    m_Mode: 4
     m_WrapAround: 0
-    m_SelectOnUp: {fileID: 0}
-    m_SelectOnDown: {fileID: 0}
+    m_SelectOnUp: {fileID: 4457197930577902350}
+    m_SelectOnDown: {fileID: 3587241309869255656}
     m_SelectOnLeft: {fileID: 0}
     m_SelectOnRight: {fileID: 0}
   m_Transition: 2
@@ -276,7 +276,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Return to Map
+  m_text: Return to Map Select
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -303,8 +303,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 24
-  m_fontSizeBase: 24
+  m_fontSize: 22
+  m_fontSizeBase: 22
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
@@ -570,9 +570,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
-    m_Mode: 3
+    m_Mode: 4
     m_WrapAround: 0
-    m_SelectOnUp: {fileID: 0}
+    m_SelectOnUp: {fileID: 4535378574528027157}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
     m_SelectOnRight: {fileID: 0}
@@ -1026,10 +1026,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
-    m_Mode: 3
+    m_Mode: 4
     m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
-    m_SelectOnDown: {fileID: 0}
+    m_SelectOnDown: {fileID: 4535378574528027157}
     m_SelectOnLeft: {fileID: 0}
     m_SelectOnRight: {fileID: 0}
   m_Transition: 2

--- a/GGK/Assets/Scenes/TrackScenes/DormRoom/GSP_RITDorm.unity
+++ b/GGK/Assets/Scenes/TrackScenes/DormRoom/GSP_RITDorm.unity
@@ -7998,6 +7998,108 @@ ParticleSystem:
         m_PostInfinity: 2
         m_RotationOrder: 4
     vectorLabel1_3: W
+--- !u!1001 &349443251
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1920549621}
+    m_Modifications:
+    - target: {fileID: 3764642559374090144, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_Name
+      value: StartPanel
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+--- !u!224 &349443252 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+  m_PrefabInstance: {fileID: 349443251}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &355355895
 GameObject:
   m_ObjectHideFlags: 0
@@ -10118,6 +10220,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   checkpointList: []
   sortedList: []
+  kartsList: []
 --- !u!1 &653159192
 GameObject:
   m_ObjectHideFlags: 0
@@ -43868,46 +43971,6 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3587241309869255656, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-      propertyPath: m_Navigation.m_Mode
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 3587241309869255656, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-      propertyPath: m_Navigation.m_SelectOnUp
-      value: 
-      objectReference: {fileID: 1666371122}
-    - target: {fileID: 4457197930577902350, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-      propertyPath: m_Navigation.m_Mode
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 4457197930577902350, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-      propertyPath: m_Navigation.m_SelectOnDown
-      value: 
-      objectReference: {fileID: 1666371122}
-    - target: {fileID: 4535378574528027157, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-      propertyPath: m_Navigation.m_Mode
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 4535378574528027157, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-      propertyPath: m_Navigation.m_SelectOnUp
-      value: 
-      objectReference: {fileID: 1666371121}
-    - target: {fileID: 4535378574528027157, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-      propertyPath: m_Navigation.m_SelectOnDown
-      value: 
-      objectReference: {fileID: 1666371120}
-    - target: {fileID: 5998075354357526364, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-      propertyPath: m_text
-      value: Return to Map Select
-      objectReference: {fileID: 0}
-    - target: {fileID: 5998075354357526364, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-      propertyPath: m_fontSize
-      value: 22
-      objectReference: {fileID: 0}
-    - target: {fileID: 5998075354357526364, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-      propertyPath: m_fontSizeBase
-      value: 22
-      objectReference: {fileID: 0}
     - target: {fileID: 6886145189342734297, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
       propertyPath: m_Name
       value: PausePanel
@@ -43935,39 +43998,6 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 5034775afa37091489599148920ff4d3, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &1666371120 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 3587241309869255656, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-  m_PrefabInstance: {fileID: 1666371117}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &1666371121 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 4457197930577902350, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-  m_PrefabInstance: {fileID: 1666371117}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 665685298}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &1666371122 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 4535378574528027157, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-  m_PrefabInstance: {fileID: 1666371117}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &1686422575
@@ -51260,6 +51290,7 @@ RectTransform:
   - {fileID: 1598205491}
   - {fileID: 1463474660}
   - {fileID: 1666371118}
+  - {fileID: 349443252}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}

--- a/GGK/Assets/Scenes/TrackScenes/GolisanoCollege/GSP_Golisano.unity
+++ b/GGK/Assets/Scenes/TrackScenes/GolisanoCollege/GSP_Golisano.unity
@@ -1054,6 +1054,7 @@ RectTransform:
   - {fileID: 773960146}
   - {fileID: 517547462}
   - {fileID: 1960714073}
+  - {fileID: 634526444}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -3656,6 +3657,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   checkpointList: []
   sortedList: []
+  kartsList: []
 --- !u!4 &395054086
 Transform:
   m_ObjectHideFlags: 0
@@ -5326,6 +5328,108 @@ MeshCollider:
   m_Convex: 0
   m_CookingOptions: 30
   m_Mesh: {fileID: 4300000, guid: 2ff144f68fb95c64abec93272605df26, type: 2}
+--- !u!1001 &634526443
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 168774468}
+    m_Modifications:
+    - target: {fileID: 3764642559374090144, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_Name
+      value: StartPanel
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+--- !u!224 &634526444 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+  m_PrefabInstance: {fileID: 634526443}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &643193555
 GameObject:
   m_ObjectHideFlags: 0
@@ -18728,53 +18832,9 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3587241309869255656, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-      propertyPath: m_Navigation.m_Mode
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 3587241309869255656, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-      propertyPath: m_Navigation.m_SelectOnUp
-      value: 
-      objectReference: {fileID: 1960714077}
-    - target: {fileID: 4457197930577902350, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-      propertyPath: m_Navigation.m_Mode
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 4457197930577902350, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-      propertyPath: m_Navigation.m_SelectOnDown
-      value: 
-      objectReference: {fileID: 1960714077}
-    - target: {fileID: 4535378574528027157, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-      propertyPath: m_Navigation.m_Mode
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 4535378574528027157, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-      propertyPath: m_Navigation.m_SelectOnUp
-      value: 
-      objectReference: {fileID: 1960714076}
-    - target: {fileID: 4535378574528027157, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-      propertyPath: m_Navigation.m_SelectOnDown
-      value: 
-      objectReference: {fileID: 1960714074}
-    - target: {fileID: 5998075354357526364, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-      propertyPath: m_text
-      value: Return to Map Select
-      objectReference: {fileID: 0}
-    - target: {fileID: 5998075354357526364, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-      propertyPath: m_fontSize
-      value: 22
-      objectReference: {fileID: 0}
-    - target: {fileID: 5998075354357526364, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-      propertyPath: m_fontSizeBase
-      value: 22
-      objectReference: {fileID: 0}
     - target: {fileID: 6886145189342734297, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
       propertyPath: m_Name
       value: PausePanel
-      objectReference: {fileID: 0}
-    - target: {fileID: 6886145189342734297, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-      propertyPath: m_IsActive
-      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -18786,44 +18846,11 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 2301379311764355640, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
   m_PrefabInstance: {fileID: 1960714072}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1960714074 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 3587241309869255656, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-  m_PrefabInstance: {fileID: 1960714072}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &1960714075 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 7439941700885712750, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
   m_PrefabInstance: {fileID: 1960714072}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1960714076 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 4457197930577902350, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-  m_PrefabInstance: {fileID: 1960714072}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1960714075}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &1960714077 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 4535378574528027157, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-  m_PrefabInstance: {fileID: 1960714072}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &1971270019
 GameObject:
   m_ObjectHideFlags: 0

--- a/GGK/Assets/Scenes/TrackScenes/OuterLoop/GSP_RITOuterLoop.unity
+++ b/GGK/Assets/Scenes/TrackScenes/OuterLoop/GSP_RITOuterLoop.unity
@@ -11585,53 +11585,9 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3587241309869255656, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-      propertyPath: m_Navigation.m_Mode
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 3587241309869255656, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-      propertyPath: m_Navigation.m_SelectOnUp
-      value: 
-      objectReference: {fileID: 300646210}
-    - target: {fileID: 4457197930577902350, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-      propertyPath: m_Navigation.m_Mode
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 4457197930577902350, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-      propertyPath: m_Navigation.m_SelectOnDown
-      value: 
-      objectReference: {fileID: 300646210}
-    - target: {fileID: 4535378574528027157, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-      propertyPath: m_Navigation.m_Mode
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 4535378574528027157, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-      propertyPath: m_Navigation.m_SelectOnUp
-      value: 
-      objectReference: {fileID: 300646209}
-    - target: {fileID: 4535378574528027157, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-      propertyPath: m_Navigation.m_SelectOnDown
-      value: 
-      objectReference: {fileID: 300646207}
-    - target: {fileID: 5998075354357526364, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-      propertyPath: m_text
-      value: Return to Map Select
-      objectReference: {fileID: 0}
-    - target: {fileID: 5998075354357526364, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-      propertyPath: m_fontSize
-      value: 22
-      objectReference: {fileID: 0}
-    - target: {fileID: 5998075354357526364, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-      propertyPath: m_fontSizeBase
-      value: 22
-      objectReference: {fileID: 0}
     - target: {fileID: 6886145189342734297, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
       propertyPath: m_Name
       value: PausePanel
-      objectReference: {fileID: 0}
-    - target: {fileID: 6886145189342734297, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-      propertyPath: m_IsActive
-      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -11654,44 +11610,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5034775afa37091489599148920ff4d3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &300646207 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 3587241309869255656, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-  m_PrefabInstance: {fileID: 300646204}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &300646208 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 7439941700885712750, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
   m_PrefabInstance: {fileID: 300646204}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &300646209 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 4457197930577902350, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-  m_PrefabInstance: {fileID: 300646204}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 300646208}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &300646210 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 4535378574528027157, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-  m_PrefabInstance: {fileID: 300646204}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &300954312
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -22337,6 +22260,108 @@ PrefabInstance:
 Transform:
   m_CorrespondingSourceObject: {fileID: 4867484192779389744, guid: 168253ed4b9e483458b295cb00a9d66f, type: 3}
   m_PrefabInstance: {fileID: 617220172}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &618115931
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1387859400}
+    m_Modifications:
+    - target: {fileID: 3764642559374090144, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_Name
+      value: StartPanel
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+--- !u!224 &618115932 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+  m_PrefabInstance: {fileID: 618115931}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &618315653
 PrefabInstance:
@@ -52084,6 +52109,7 @@ RectTransform:
   - {fileID: 1057509601}
   - {fileID: 92987566}
   - {fileID: 300646205}
+  - {fileID: 618115932}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}

--- a/GGK/Assets/Scenes/TrackScenes/QuarterMile/GSP_RITQuarterMile.unity
+++ b/GGK/Assets/Scenes/TrackScenes/QuarterMile/GSP_RITQuarterMile.unity
@@ -5840,53 +5840,9 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3587241309869255656, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-      propertyPath: m_Navigation.m_Mode
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 3587241309869255656, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-      propertyPath: m_Navigation.m_SelectOnUp
-      value: 
-      objectReference: {fileID: 219574019}
-    - target: {fileID: 4457197930577902350, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-      propertyPath: m_Navigation.m_Mode
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 4457197930577902350, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-      propertyPath: m_Navigation.m_SelectOnDown
-      value: 
-      objectReference: {fileID: 219574019}
-    - target: {fileID: 4535378574528027157, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-      propertyPath: m_Navigation.m_Mode
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 4535378574528027157, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-      propertyPath: m_Navigation.m_SelectOnUp
-      value: 
-      objectReference: {fileID: 219574020}
-    - target: {fileID: 4535378574528027157, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-      propertyPath: m_Navigation.m_SelectOnDown
-      value: 
-      objectReference: {fileID: 219574018}
-    - target: {fileID: 5998075354357526364, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-      propertyPath: m_text
-      value: Return to Map Select
-      objectReference: {fileID: 0}
-    - target: {fileID: 5998075354357526364, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-      propertyPath: m_fontSize
-      value: 22
-      objectReference: {fileID: 0}
-    - target: {fileID: 5998075354357526364, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-      propertyPath: m_fontSizeBase
-      value: 22
-      objectReference: {fileID: 0}
     - target: {fileID: 6886145189342734297, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
       propertyPath: m_Name
       value: PausePanel
-      objectReference: {fileID: 0}
-    - target: {fileID: 6886145189342734297, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-      propertyPath: m_IsActive
-      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -5903,39 +5859,6 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 7439941700885712750, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
   m_PrefabInstance: {fileID: 219574015}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &219574018 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 3587241309869255656, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-  m_PrefabInstance: {fileID: 219574015}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &219574019 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 4535378574528027157, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-  m_PrefabInstance: {fileID: 219574015}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &219574020 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 4457197930577902350, guid: 0fd4fd25d192327469b91954682fa507, type: 3}
-  m_PrefabInstance: {fileID: 219574015}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 219574017}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &228658419
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -6091,8 +6014,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 255361261}
   serializedVersion: 2
-  m_LocalRotation: {x: -0.00045392136, y: -0.6925859, z: 0.0004696785, w: 0.7213352}
-  m_LocalPosition: {x: 14.24, y: -2.55, z: 19.9}
+  m_LocalRotation: {x: -0.00045392136, y: -0.692586, z: 0.00046967843, w: 0.72133505}
+  m_LocalPosition: {x: 17.599182, y: -2.5658264, z: 20.43396}
   m_LocalScale: {x: 1.9523599, y: 1.9523599, z: 1.9523599}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -36173,7 +36096,7 @@ Transform:
   m_GameObject: {fileID: 1464056429}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0.6815358, z: -0, w: 0.7317848}
-  m_LocalPosition: {x: 923.56, y: -185.73, z: 1604.78}
+  m_LocalPosition: {x: 932.88, y: -185.73, z: 1621.54}
   m_LocalScale: {x: 56.314236, y: 56.314236, z: 56.314236}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -52665,6 +52588,7 @@ RectTransform:
   - {fileID: 919015160}
   - {fileID: 1976424561}
   - {fileID: 219574016}
+  - {fileID: 2125479232}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -59568,6 +59492,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   checkpointList: []
   sortedList: []
+  kartsList: []
 --- !u!1 &2101301565
 GameObject:
   m_ObjectHideFlags: 0
@@ -59733,6 +59658,108 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2111577810}
   m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1001 &2125479231
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1697284452}
+    m_Modifications:
+    - target: {fileID: 3764642559374090144, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_Name
+      value: StartPanel
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+--- !u!224 &2125479232 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 7736921597497755662, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+  m_PrefabInstance: {fileID: 2125479231}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &2134104055
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Because names are set to lower when checking which model to set active, it cannot find OL model since it is uppercase.

Temporary fix to Appearance Settings, now it checks if the kart is the player kart before grabbing CharacterData information. NPC kart icons are currently manually set in scene.

Applied Jaden's changes to the Pause prefab because the changes were only made to the instances in the scenes itself.