### PR TITLE
Shield indicator

### DIFF
--- a/GGK/Assets/Scripts/ItemScripts/ItemBox.cs
+++ b/GGK/Assets/Scripts/ItemScripts/ItemBox.cs
@@ -41,7 +41,7 @@ public class ItemBox : MonoBehaviour
         ItemHolder itemScript = kart.GetComponent<ItemHolder>();
 
         Debug.Log("Collided!");
-        BaseItem bItem = Instantiate(items[2]);
+        BaseItem bItem = Instantiate(items[Random.Range(0, 5)]);
         itemScript.HeldItem = bItem;
         itemScript.HeldItem.ItemTier = 1;
         bItem.gameObject.SetActive(false);

--- a/GGK/Assets/Scripts/ItemScripts/Shield.cs
+++ b/GGK/Assets/Scripts/ItemScripts/Shield.cs
@@ -1,13 +1,33 @@
 using System.Collections;
 using System.Collections.Generic;
+using Unity.VisualScripting;
 using UnityEngine;
 
 public class Shield : BaseItem
 {
+    // save the default color of the shield
+    private Renderer renderer;
+    private Material material;
+    private Color defaultColor;
+    // the color the shield flashes the last few seconds of it's duration
+    private Color timerColor;
+
+    // the interval between color switches on the shield
+    private float blinkInterval = 0.5f;
+
+    // the time when the shield should indicate it's ending
+    private float indicatorTime = 3.0f;
+
     // Start is called before the first frame update
     void Start()
     {
+        // save the default color of the shield
+        renderer = GetComponent<Renderer>();
+        material = renderer.material;
+        defaultColor = material.color;
 
+        timerColor = Color.red;
+        timerColor.a = defaultColor.a;
     }
 
     // Update is called once per frame
@@ -15,6 +35,12 @@ public class Shield : BaseItem
     {
         // Counts down to despawn
         DecreaseTimer();
+
+        if (timer <= indicatorTime)
+        {
+            // flash a different color to indicate the shield is ending
+            StartCoroutine(ColorBlink());
+        }
 
         // Sets shield position to the karts position
         if (kart)
@@ -30,5 +56,22 @@ public class Shield : BaseItem
         {
             Destroy(collision.gameObject);
         }
+    }
+
+    IEnumerator ColorBlink()
+    {
+        float elapsed = 0f;
+        bool toggleColor = false;
+
+        while(elapsed < indicatorTime)
+        {
+            material.color = toggleColor ? defaultColor : timerColor;
+            toggleColor = !toggleColor;
+
+            yield return new WaitForSeconds(blinkInterval);
+            elapsed += blinkInterval;
+        }
+
+        material.color = defaultColor;
     }
 }

--- a/GGK/Assets/Scripts/ItemScripts/Shield.cs
+++ b/GGK/Assets/Scripts/ItemScripts/Shield.cs
@@ -16,7 +16,7 @@ public class Shield : BaseItem
     private float blinkInterval = 0.5f;
 
     // the time when the shield should indicate it's ending
-    private float indicatorTime = 3.0f;
+    private float indicatorTime = 2.0f;
 
     // Start is called before the first frame update
     void Start()


### PR DESCRIPTION
In the last 2 seconds of a Shield's life, it flashes red to indicate it'll be ending