### PR TITLE
Buttons bounded when Start Scene is re-entered

### DIFF
--- a/GGK/Assets/Scenes/StartScene.unity
+++ b/GGK/Assets/Scenes/StartScene.unity
@@ -214,6 +214,52 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &59390593
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 59390594}
+  - component: {fileID: 59390595}
+  m_Layer: 0
+  m_Name: StartSceneHandler
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &59390594
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 59390593}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 150.1226, y: -122.61684, z: -44.242065}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &59390595
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 59390593}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c18e80a90360bf34b8aa2c943b3bc561, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  startButton: {fileID: 904248810}
+  quitButton: {fileID: 866175340}
 --- !u!1 &193614646
 GameObject:
   m_ObjectHideFlags: 0
@@ -2743,4 +2789,4 @@ SceneRoots:
   - {fileID: 222860815}
   - {fileID: 1437372378}
   - {fileID: 193614649}
-  - {fileID: 239081864}
+  - {fileID: 59390594}


### PR DESCRIPTION
The StartSceneHandler is added to the Start Scene so the Start and Exit buttons have their expected functions when a player gets to this scene using the Go Back button or returns to start during or after a race.