### PR TITLE
Shield Fixes and Upgrade Icons

### DIFF
--- a/GGK/Assets/Materials/ShieldMaterial.mat
+++ b/GGK/Assets/Materials/ShieldMaterial.mat
@@ -22,6 +22,7 @@ Material:
     RenderType: Transparent
   disabledShaderPasses:
   - DepthOnly
+  - SHADOWCASTER
   m_LockedProperties: 
   m_SavedProperties:
     serializedVersion: 3
@@ -118,7 +119,7 @@ Material:
     - _ZWrite: 0
     m_Colors:
     - _BaseColor: {r: 0, g: 1, b: 0.9712162, a: 0.3137255}
-    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _Color: {r: 0, g: 1, b: 0.9712162, a: 0.3137255}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
     - _SpecColor: {r: 0.2, g: 0.2, b: 0.2, a: 1}
   m_BuildTextureStacks: []

--- a/GGK/Assets/Prefabs/ItemPrefabs/Boost.prefab
+++ b/GGK/Assets/Prefabs/ItemPrefabs/Boost.prefab
@@ -72,7 +72,12 @@ MonoBehaviour:
   itemCategory: Boost
   useCount: 1
   isTimed: 0
+  timerCounting: 0
   itemIcon: {fileID: 2800000, guid: dd04c03d55919a941bcc2ac0d7bf7c5c, type: 3}
+  tierOneItemIcon: {fileID: 2800000, guid: dd04c03d55919a941bcc2ac0d7bf7c5c, type: 3}
+  tierTwoItemIcon: {fileID: 2800000, guid: 3f2cc56be0445fb419d73b151aee8219, type: 3}
+  tierThreeItemIcon: {fileID: 2800000, guid: bbb2ae3fc278a4e4c9f6b480d450eb0e, type: 3}
+  tierFourItemIcon: {fileID: 2800000, guid: b6355c8061d93c6408bee787c3829662, type: 3}
 --- !u!54 &1030214434015564131
 Rigidbody:
   m_ObjectHideFlags: 0

--- a/GGK/Assets/Prefabs/ItemPrefabs/Shield.prefab
+++ b/GGK/Assets/Prefabs/ItemPrefabs/Shield.prefab
@@ -15,7 +15,7 @@ GameObject:
   - component: {fileID: 4323936219153965337}
   m_Layer: 0
   m_Name: Shield
-  m_TagString: Untagged
+  m_TagString: Shield
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -123,4 +123,8 @@ MonoBehaviour:
   itemCategory: Shield
   useCount: 1
   isTimed: 1
-  itemIcon: {fileID: 2800000, guid: d4af179105362874ab6377ae9550b2a6, type: 3}
+  itemIcon: {fileID: 2800000, guid: 23742be16381b6e4ca5e285b12452e7d, type: 3}
+  tierOneItemIcon: {fileID: 2800000, guid: 23742be16381b6e4ca5e285b12452e7d, type: 3}
+  tierTwoItemIcon: {fileID: 2800000, guid: e2ac44bbc8c63d946862bf72195a026a, type: 3}
+  tierThreeItemIcon: {fileID: 2800000, guid: f1c4e36e72b3de44f8ea08e03e01a611, type: 3}
+  tierFourItemIcon: {fileID: 2800000, guid: d3885e7dc1cd1e04099e5476bafe9881, type: 3}

--- a/GGK/Assets/Scripts/ItemScripts/BaseItem.cs
+++ b/GGK/Assets/Scripts/ItemScripts/BaseItem.cs
@@ -61,10 +61,10 @@ public class BaseItem : MonoBehaviour
         // Destroys the item
         else
         {
-            if (itemCategory != "Shield")
-            {
+            //if (itemCategory != "Shield")
+            //{
                 Destroy(this.gameObject);
-            }
+            //}
         }
     }
 
@@ -93,6 +93,8 @@ public class BaseItem : MonoBehaviour
                     useCount = 1;
                     break;
             }
+            Boost boost = (Boost)this;
+            boost.LevelUp();
         }
         else if (itemCategory == "Shield") // changes timer on different shield levels
         {
@@ -112,6 +114,8 @@ public class BaseItem : MonoBehaviour
                     timer = 4.0f;
                     break;
             }
+            Shield shield = (Shield)this;
+            shield.LevelUp();
             useCount = 1;
         }
         else if (itemCategory == "Hazard")

--- a/GGK/Assets/Scripts/ItemScripts/Boost.cs
+++ b/GGK/Assets/Scripts/ItemScripts/Boost.cs
@@ -5,6 +5,15 @@ using UnityEngine;
 
 public class Boost : BaseItem
 {
+    // item icons for each tier
+    [SerializeField]
+    public Texture tierOneItemIcon;
+    [SerializeField]
+    public Texture tierTwoItemIcon;
+    [SerializeField]
+    public Texture tierThreeItemIcon;
+    [SerializeField]
+    public Texture tierFourItemIcon;
 
     private void Awake()
     {
@@ -15,6 +24,26 @@ public class Boost : BaseItem
     void FixedUpdate()
     {
         // DecreaseTimer();
+    }
+
+    public void LevelUp()
+    {
+        // update the icon based on the item tier
+        switch (itemTier)
+        {
+            case 2:
+                itemIcon = tierTwoItemIcon;
+                break;
+            case 3:
+                itemIcon = tierThreeItemIcon;
+                break;
+            case 4:
+                itemIcon = tierFourItemIcon;
+                break;
+            default:
+                itemIcon = tierOneItemIcon;
+                break;
+        }
     }
 
     // the boost spawns on the user as an empty gameobject and applies a force to the kart

--- a/GGK/Assets/Scripts/ItemScripts/ItemHolder.cs
+++ b/GGK/Assets/Scripts/ItemScripts/ItemHolder.cs
@@ -247,10 +247,21 @@ public class ItemHolder : MonoBehaviour
             UpgradeBox upgradeBox = collision.gameObject.GetComponent<UpgradeBox>();
             // itemDisplay.texture = heldItem.itemIcon;
 
-            // if player missing item, gives random level 2 item or upgrades current item
-            upgradeBox.UpgradeItem(this.gameObject);
-            heldItem.OnLevelUp(heldItem.ItemTier);
-            uses = heldItem.UseCount;
+            // Checks if the heldItem is anything but a shield
+            if (heldItem == null || !heldItem.gameObject.CompareTag("Shield"))
+            {
+                // if player missing item, gives random level 2 item or upgrades current item
+                upgradeBox.UpgradeItem(this.gameObject);
+                heldItem.OnLevelUp(heldItem.ItemTier);
+                uses = heldItem.UseCount;
+            }
+            else if (uses == 1) // if the shield isn't being used, uses will be 1
+            {
+                // if player missing item, gives random level 2 item or upgrades current item
+                upgradeBox.UpgradeItem(this.gameObject);
+                heldItem.OnLevelUp(heldItem.ItemTier);
+                uses = heldItem.UseCount;
+            }
 
             // Either upgrades the current item or gives the kart a random upgraded item
             //baseItem = upgradeBox.UpgradeItem(this);

--- a/GGK/Assets/Scripts/ItemScripts/Shield.cs
+++ b/GGK/Assets/Scripts/ItemScripts/Shield.cs
@@ -12,6 +12,16 @@ public class Shield : BaseItem
     // the color the shield flashes the last few seconds of it's duration
     private Color timerColor;
 
+    // item icons for each tier
+    [SerializeField]
+    public Texture tierOneItemIcon;
+    [SerializeField]
+    public Texture tierTwoItemIcon;
+    [SerializeField]
+    public Texture tierThreeItemIcon;
+    [SerializeField]
+    public Texture tierFourItemIcon;
+
     // the interval between color switches on the shield
     private float blinkInterval = 1.0f;
 
@@ -55,6 +65,28 @@ public class Shield : BaseItem
         if (collision.gameObject.CompareTag("Projectile") || collision.gameObject.CompareTag("Hazard"))
         {
             Destroy(collision.gameObject);
+        }
+    }
+
+    // Should be moved to BaseItem to be overridable
+    // Added separately for now so there aren't big conflicts with the Puck when that's pushed
+    public void LevelUp()
+    {
+        // update the icon based on the item tier
+        switch (itemTier)
+        {
+            case 2:
+                itemIcon = tierTwoItemIcon;
+                break;
+            case 3:
+                itemIcon = tierThreeItemIcon;
+                break;
+            case 4:
+                itemIcon = tierFourItemIcon;
+                break;
+            default:
+                itemIcon = tierOneItemIcon;
+                break;
         }
     }
 

--- a/GGK/ProjectSettings/TagManager.asset
+++ b/GGK/ProjectSettings/TagManager.asset
@@ -21,6 +21,7 @@ TagManager:
   - Obstacle
   - Rock
   - Road
+  - Shield
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
The Shield and Boost item have the upgraded item icons added for each tier.

The Shield can no longer but upgraded while it's actively being used, which avoids stacking multiple shields and other bugs that were exclusive to the shield