### PR TITLE
removed camera and light from Kai model

### DIFF
--- a/GGK/Assets/Prefabs/Kart 1.prefab
+++ b/GGK/Assets/Prefabs/Kart 1.prefab
@@ -110804,7 +110804,12 @@ MonoBehaviour:
   timer: 5
   itemDisplay: {fileID: 0}
   defaultItemDisplay: {fileID: 2800000, guid: 7b68c3fd2d2e4ab4c9af6a29ab528b67, type: 3}
+  uses: 0
+  gravityForce: 0
   miniMap: {fileID: 0}
+  length: 4
+  strength: 5
+  dampening: 20
 --- !u!114 &8552696247647127666
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -121403,7 +121408,9 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 2100000, guid: 02d6cb2f832fa3949abaa8adb56df964, type: 2}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
+    m_RemovedGameObjects:
+    - {fileID: -8700617353114198275, guid: 13433cd13ada20f4589dcc88ea1697bb, type: 3}
+    - {fileID: 65702495048144492, guid: 13433cd13ada20f4589dcc88ea1697bb, type: 3}
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 13433cd13ada20f4589dcc88ea1697bb, type: 3}


### PR DESCRIPTION
There was a camera object under the kai model in the kart1 prefab which seemed to be taking priority over the scene camera whenever kai was picked for a race, thus resulting in only a greybox being visible. Deleting the camera within the prefab seemed to fix the issue. No other racer model had this camera which seems to be why it only occured with Kai.