### PR TITLE
Solving issue #410

### DIFF
--- a/GGK/Assets/AppearanceSettings.cs
+++ b/GGK/Assets/AppearanceSettings.cs
@@ -33,7 +33,7 @@ public class AppearanceSettings : MonoBehaviour
                     if (name == models[i].name)
                     {
                         models[i].SetActive(true);
-                        break;
+                        continue;
                     }
 
                     //deleting the models that are not supposed to be active


### PR DESCRIPTION
The previous issue was that because it was a break line instead of a continue the loop stopped early before destroying the jamster model since it is futher down the list than other models.

By default the jamster model is active so it is noticeable when it is not destroyed. When other models are not destroyed you can't really tell since they are inactive by default.