### PR TITLE
Trap Items fall

### DIFF
--- a/GGK/Assets/Prefabs/ItemPrefabs/TrapItem.prefab
+++ b/GGK/Assets/Prefabs/ItemPrefabs/TrapItem.prefab
@@ -132,7 +132,7 @@ Rigidbody:
   m_UseGravity: 1
   m_IsKinematic: 0
   m_Interpolate: 0
-  m_Constraints: 126
+  m_Constraints: 122
   m_CollisionDetection: 0
 --- !u!114 &5201143229639170716
 MonoBehaviour:

--- a/GGK/Assets/Scripts/ItemScripts/TrapItem.cs
+++ b/GGK/Assets/Scripts/ItemScripts/TrapItem.cs
@@ -31,6 +31,12 @@ public class TrapItem : BaseItem
             Vector3 behindPos = transform.position - transform.forward * 6 + transform.up * 3;
             transform.position = behindPos;
         }
+
+        // freeze the fake item box's Y position
+        if(itemTier == 4)
+        {
+            rb.constraints = RigidbodyConstraints.FreezePositionY;
+        }
         
         // sends the hazard slightly up and behind the player before landing on the ground
         // rb.AddForce(transform.forward * -750.0f + transform.up * 50.0f);
@@ -42,6 +48,16 @@ public class TrapItem : BaseItem
         if (itemTier > 2)
         {
             RotateBox();
+        }
+    }
+
+    private void OnTriggerEnter(Collider collision)
+    {
+        // stop the trap from falling when they reach the ground/road
+        // for every tier except fake item box (it naturally floats a little)
+        if(itemTier < 4 && (collision.gameObject.CompareTag("Ground") || collision.gameObject.CompareTag("Road")))
+        {
+            rb.constraints = RigidbodyConstraints.FreezePositionY;
         }
     }
 


### PR DESCRIPTION
Trap items (excluding the tier 4 fake item box as the base item boxes are somewhat floating) will now fall down to the ground when used.