### PR TITLE
timer and fullscreen fix

### DIFF
--- a/GGK/Assets/Scripts/GameManagers/MultiplayerManager.cs
+++ b/GGK/Assets/Scripts/GameManagers/MultiplayerManager.cs
@@ -188,6 +188,11 @@ public class MultiplayerManager : NetworkBehaviour
 
     private void FindTimer()
     {
+        // set run timer false when entering new scene
+        runKartSelectionTimer = false;
+        runMapSelectionTimer = false;
+
+        // If in PlayerKartScene set timer to kartSelectionTimerMax and make it run
         if (SceneManager.GetActiveScene().name == "PlayerKartScene")
         {
             timer = GameObject.Find("Timer");
@@ -207,6 +212,7 @@ public class MultiplayerManager : NetworkBehaviour
                 timer.SetActive(false);
             }
         }
+        // If in MapSelectScene set timer to mapSelectionTimerMax and make it run
         else if (SceneManager.GetActiveScene().name == "MapSelectScene")
         {
             timer = GameObject.Find("Timer");

--- a/GGK/Assets/Scripts/GameManagers/OptionsHandler.cs
+++ b/GGK/Assets/Scripts/GameManagers/OptionsHandler.cs
@@ -30,6 +30,8 @@ public class OptionsHandler : MonoBehaviour
     public TMP_InputField widthInputField;
     public TMP_InputField heightInputField;
 
+    private bool initalizing;
+
     private void Update()
     {
         // Updates resolution text fields when resolution changes
@@ -58,6 +60,8 @@ public class OptionsHandler : MonoBehaviour
     // Initialize saved values from OptionsData
     public void SetOptions()
     {
+        initalizing = true;
+
         masterVolumeSlider.value = optionsData.masterVolume;
         masterVolumeValue.text = optionsData.masterVolume.ToString();
 
@@ -85,6 +89,8 @@ public class OptionsHandler : MonoBehaviour
         optionsData.resolution.y = Screen.height;
         widthInputField.text = optionsData.resolution.x.ToString();
         heightInputField.text = optionsData.resolution.y.ToString();
+
+        initalizing = false;
     }
 
     // Methods to attach to options panel interactables
@@ -110,6 +116,8 @@ public class OptionsHandler : MonoBehaviour
     }
     public void FullScreenChange()
     {
+        if (initalizing) return;
+
         if (optionsData.IsFullScreen)
         {
             optionsData.IsFullScreen = false;


### PR DESCRIPTION
Fullscreen will no longer toggle on or off if IsFullScreen is false when activating options panel.

Timer will stop running if moved to another scene before timer naturally runs out.