### PR TITLE
Countdown Synced in Multiplayer

### DIFF
--- a/GGK/Assets/Prefabs/StartPanel.prefab
+++ b/GGK/Assets/Prefabs/StartPanel.prefab
@@ -65,7 +65,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 3
+  m_text: 
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -146,6 +146,7 @@ GameObject:
   - component: {fileID: 3461695014893716152}
   - component: {fileID: 6935072206630113756}
   - component: {fileID: 4970949486164175069}
+  - component: {fileID: -2367733819248507835}
   - component: {fileID: 9047304405766018224}
   m_Layer: 5
   m_Name: StartPanel
@@ -224,6 +225,27 @@ CanvasGroup:
   m_Interactable: 0
   m_BlocksRaycasts: 0
   m_IgnoreParentGroups: 0
+--- !u!114 &-2367733819248507835
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3764642559374090144}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  GlobalObjectIdHash: 4120440635
+  InScenePlacedSourceGlobalObjectIdHash: 0
+  AlwaysReplicateAsRoot: 0
+  SynchronizeTransform: 1
+  ActiveSceneSynchronization: 0
+  SceneMigrationSynchronization: 1
+  SpawnWithObservers: 1
+  DontDestroyWithOwner: 0
+  AutoObjectParentSync: 1
 --- !u!114 &9047304405766018224
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -236,6 +258,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 675078c898ad0f140bc05018c81aa148, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  startPanel: {fileID: 4970949486164175069}
   countdownText: {fileID: 471504874506883914}
+  countdownStart: 3
   countdownSpeed: 1
+  finished: 0

--- a/GGK/Assets/Scenes/TrackScenes/DormRoom/GSP_RITDorm.unity
+++ b/GGK/Assets/Scenes/TrackScenes/DormRoom/GSP_RITDorm.unity
@@ -8545,6 +8545,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1920549621}
     m_Modifications:
+    - target: {fileID: 471504874506883914, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: m_text
+      value: 
+      objectReference: {fileID: 0}
     - target: {fileID: 3764642559374090144, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
       propertyPath: m_Name
       value: StartPanel

--- a/GGK/Assets/Scenes/TrackScenes/FinalsBrickRoad/GSP_FinalsBrickRoad.unity
+++ b/GGK/Assets/Scenes/TrackScenes/FinalsBrickRoad/GSP_FinalsBrickRoad.unity
@@ -1186,6 +1186,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1716925573}
     m_Modifications:
+    - target: {fileID: -2367733819248507835, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 728693222
+      objectReference: {fileID: 0}
     - target: {fileID: 3764642559374090144, guid: d9593fa36c39d724e8df175aacb3130c, type: 3}
       propertyPath: m_Name
       value: StartPanel
@@ -3441,6 +3445,10 @@ MonoBehaviour:
   curTime: 0
   networkTime:
     m_InternalValue: 0
+  numOfPlayerKarts: 0
+  allPlayerKartsFinished:
+    m_InternalValue: 0
+  finishedPlayerKarts: []
 --- !u!4 &604657646
 Transform:
   m_ObjectHideFlags: 0

--- a/GGK/Assets/Scripts/HUDScripts/Countdown.cs
+++ b/GGK/Assets/Scripts/HUDScripts/Countdown.cs
@@ -208,6 +208,8 @@ public class Countdown : NetworkBehaviour
 
     IEnumerator ServerCountdownRoutine()
     {
+        yield return new WaitForSecondsRealtime(countdownSpeed);
+
         int count = countdownStart;
 
         while (count > 0)
@@ -224,6 +226,8 @@ public class Countdown : NetworkBehaviour
 
     IEnumerator LocalCountdownRoutine()
     {
+        yield return new WaitForSecondsRealtime(countdownSpeed);
+
         int count = countdownStart;
 
         while (count > 0)


### PR DESCRIPTION
Reworked countdown script to work in single and multiplayer. Removed default text (3) from text meshes of countdown prefab (under the StartPanel prefab on the Countdown prefab).