### PR TITLE
Fixed back button 2 calls

### DIFF
--- a/GGK/Assets/Scenes/MultiplayerMenus.unity
+++ b/GGK/Assets/Scenes/MultiplayerMenus.unity
@@ -975,6 +975,17 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2bf65969b35adc24f9c0b13515519eea, type: 3}
+--- !u!114 &302036857 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 740516601579092275, guid: 2bf65969b35adc24f9c0b13515519eea, type: 3}
+  m_PrefabInstance: {fileID: 302036856}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 61aed96faebb5d4489c8f5a950524851, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &310259625
 GameObject:
   m_ObjectHideFlags: 0
@@ -7008,9 +7019,9 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 0}
+      - m_Target: {fileID: 302036857}
         m_TargetAssemblyTypeName: BackButtonHandler, Assembly-CSharp
-        m_MethodName: 
+        m_MethodName: GoBack
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}

--- a/GGK/Assets/Scripts/GameManagers/BackButtonHandler.cs
+++ b/GGK/Assets/Scripts/GameManagers/BackButtonHandler.cs
@@ -16,10 +16,7 @@ public class BackButtonHandler : MonoBehaviour
     {
         gamemanagerObj = FindAnyObjectByType<GameManager>();
 
-        // assign back button
         Button button = backOption.GetComponent<Button>();
-        button.onClick.AddListener(() =>
-            GetComponent<BackButtonHandler>().GoBack());
 
         // back button is inactive during multiplayer
         if (MultiplayerManager.Instance.IsMultiplayer)
@@ -97,7 +94,7 @@ public class BackButtonHandler : MonoBehaviour
                 gamemanagerObj.curState = GameStates.gameMode;
                 break;
             case GameStates.map:
-                gamemanagerObj.sceneLoader.LoadScene("PlayerKartScene");
+                gamemanagerObj.sceneLoader.LoadScene("CharSelectMenu");
                 gamemanagerObj.curState = GameStates.playerKart;
                 break;
             default:


### PR DESCRIPTION
Fixed a bug where the back button was called twice onclick, making the user go back 2 scenes instead of one