### PR TITLE
The lobby list now auto refreshes

### DIFF
--- a/GGK/Assets/Scripts/GameManagers/LobbyManager.cs
+++ b/GGK/Assets/Scripts/GameManagers/LobbyManager.cs
@@ -117,7 +117,7 @@ public class LobbyManager : MonoBehaviour
     #region looping functions
     private void Update()
     {
-        //HandleRefreshLobbyList(); // Disabled for testing so that we dont hit rate limit within the same IP
+        HandleRefreshLobbyList(); // Disabled for testing so that we dont hit rate limit within the same IP
         HandleLobbyHeartbeat();
         HandleLobbyPollForUpdates();
     }


### PR DESCRIPTION
The lobby list now refreshes on a 1.1s interval.
It was one line commented out that I've had there from the beginning.
I'm doing it now incase I don't get the chance to later.